### PR TITLE
onCellEnter & onClose callbacks added

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -106,6 +106,13 @@ callback:           Function to be called when a color is selected. The
                     hex code is passed into the function.
                      default value: null
 
+onCellEnter:        Callback function that excecutes when a cell is entered by the user's mouse
+                    Default value: null
+                     Returns: Hex Value
+
+onClose:            Callback function that executes whenever the chooser is closed
+                     Default value: null
+
 ```
 
 Building From Scratch

--- a/examples/index.html
+++ b/examples/index.html
@@ -8,6 +8,7 @@
 
 <script  type="text/javascript">
 $(document).ready(function(){
+
   $('.simple_color').simpleColor();
 
   $('.simple_color_color_code').simpleColor({ displayColorCode: true });
@@ -28,6 +29,12 @@ $(document).ready(function(){
       displayColorCode: true,
       callback: function( hex ) {
         alert("You selected #" + hex);
+      },
+      onCellEnter: function( hex ) {
+        console.log("You just entered #" + hex);
+      },
+      onClose: function() {
+        alert("color selector closed");
       }
   });
 

--- a/src/jquery.simple-color.js
+++ b/src/jquery.simple-color.js
@@ -56,6 +56,15 @@
  *
  *  callback:           Callback function to call after a color has been chosen.
  *                      Default value: null
+ *                      Returns: Hex Value
+ *
+ *  onCellEnter:        Callback function that excecutes when a cell is entered by the user's mouse
+ *                      Default value: null
+ *                      Returns: Hex Value
+ *
+ *  onClose:            Callback function that executes whenever the chooser is closed
+ *                      Default value: null
+ *
  */
   $.fn.simpleColor = function(options) {
 
@@ -106,7 +115,9 @@
       displayColorCode: this.attr('displayColorCode') || false,
       colorCodeAlign:   this.attr('colorCodeAlign') || 'center',
       colorCodeColor:   this.attr('colorCodeColor') || '#FFF',
-      callback:         null
+      callback: null,
+      onCellEnter: null,
+      onClose: null
     }, options || {});
 
     // Hide the input
@@ -133,7 +144,7 @@
       var container = $("<div class='simpleColorContainer' />");
       
       // Absolutely positioned child elements now 'work'.
-			container.css('position', 'relative');
+            container.css('position', 'relative');
 
       // Create the color display box
       var default_color = (this.value && this.value != '') ? this.value : options.defaultColor;
@@ -141,13 +152,13 @@
       var display_box = $("<div class='simpleColorDisplay' />");
       display_box.css({
         'backgroundColor': default_color,
-      	'border':          options.border,
-				'width':           options.boxWidth,
-				'height':          options.boxHeight,
-				// Make sure that the code is vertically centered.
-				'line-height':     options.boxHeight,
-				'cursor':          'pointer'
-			});
+        'border':          options.border,
+                'width':           options.boxWidth,
+                'height':          options.boxHeight,
+                // Make sure that the code is vertically centered.
+                'line-height':     options.boxHeight,
+                'cursor':          'pointer'
+            });
       container.append(display_box);
       
       // If 'displayColorCode' is turned on, display the currently selected color code as text inside the button.
@@ -155,11 +166,22 @@
         display_box.text(this.value);
         display_box.css({
           'color':     options.colorCodeColor,
-        	'textAlign': options.colorCodeAlign
+            'textAlign': options.colorCodeAlign
         });
       }
       
       var select_callback = function (event) {
+
+        // bind and namespace the click listener only when the chooser is displayed
+        // unbind when the chooser is closed
+        $('html').bind("click.simpleColorDisplay", function() {
+          $('html').unbind("click.simpleColorDisplay");
+          $('.simpleColorChooser').hide();
+
+          if (options.onClose) {
+            options.onClose();
+          }
+        });
 
         // Use an existing chooser if there is one
         if (event.data.container.chooser) {
@@ -172,13 +194,13 @@
           var chooser = $("<div class='simpleColorChooser'/>");
           chooser.css({
             'border':   options.border,
-			      'margin':   '0 0 0 5px',
-			      'width':    options.totalWidth,
-			      'height':   options.totalHeight,
-						'top':      0,
-						'left':     options.boxWidth,
-						'position': 'absolute'
-					});
+                  'margin':   '0 0 0 5px',
+                  'width':    options.totalWidth,
+                  'height':   options.totalHeight,
+                        'top':      0,
+                        'left':     options.boxWidth,
+                        'position': 'absolute'
+                    });
       
           event.data.container.chooser = chooser;
           event.data.container.append(chooser);
@@ -188,15 +210,21 @@
             var cell = $("<div class='simpleColorCell' id='" + options.colors[i] + "'/>");
             cell.css({
               'width':           options.cellWidth + 'px',
-             	'height':          options.cellHeight + 'px',
-			        'margin':          options.cellMargin + 'px',
-			        'cursor':          'pointer',
-			        'lineHeight':      options.cellHeight + 'px',
-			        'fontSize':        '1px',
-			        'float':           'left',
-			        'backgroundColor': '#'+options.colors[i]
-			      });
+                'height':          options.cellHeight + 'px',
+                    'margin':          options.cellMargin + 'px',
+                    'cursor':          'pointer',
+                    'lineHeight':      options.cellHeight + 'px',
+                    'fontSize':        '1px',
+                    'float':           'left',
+                    'backgroundColor': '#'+options.colors[i]
+                  });
             chooser.append(cell);
+
+            if (options.onCellEnter) {
+              cell.bind('mouseenter', function(event) {
+                options.onCellEnter(this.id)
+              });
+            }
 
             cell.bind('click', {
               input: event.data.input, 
@@ -214,6 +242,7 @@
               if (options.displayColorCode) {
                 event.data.display_box.text('#' + this.id);
               }
+
               // If a callback function is defined then excecute it.
               if (options.callback) {
                 options.callback(this.id);
@@ -239,15 +268,11 @@
 
     this.each(buildSelector);
 
-		$('html').click(function() {
-			$('.simpleColorChooser').hide();
-		});
-		
-		$('.simpleColorDisplay').each(function() {
-			$(this).click(function(e){
-				e.stopPropagation();
-			});
-		});
+        $('.simpleColorDisplay').each(function() {
+            $(this).click(function(e){
+                e.stopPropagation();
+            });
+        });
 
     return this;
   };


### PR DESCRIPTION
added two optional callbacks that can be useful for devs
- onCellEnter - for when the user mouses over a color cell. useful if you need to tell other parts of the application when a color is being moused over (previews etc).
- onClose - executes whenever the color selector is closed for any reason (selection, blurring).

Also included is a more discerning bind logic that only listens for clicks (to close) when the color selector is open and is unbound when it's closed:

``` javascript
$('html').bind("click.simpleColorDisplay", function() {
  $('html').unbind("click.simpleColorDisplay");
  $('.simpleColorChooser').hide();

  if (options.onClose) {
    options.onClose();
  }
});
```

usage

``` javascript
$('.colorselector').simpleColor({
      onCellEnter: function( hex ) {
        console.log("You just entered #" + hex);
      },
      onClose: function() {
        alert("color selector closed");
      },
  });
```
