### PR TITLE
Adds a Live Preview that updates the color display as the user mouses over the color cells

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -113,6 +113,10 @@ onCellEnter:        Callback function that excecutes when a cell is entered by t
 onClose:            Callback function that executes whenever the chooser is closed
                      Default value: null
 
+livePreview:        The color display will change to show the color of the hovered color cell.
+                    The display will revert if no color is selected.
+                     Default value: false
+
 ```
 
 Building From Scratch

--- a/examples/index.html
+++ b/examples/index.html
@@ -15,6 +15,10 @@ $(document).ready(function(){
 
   $('.simple_color_custom_cell_size').simpleColor({ cellWidth: 30, cellHeight: 10 });
 
+  $('.simple_color_live_preview').simpleColor({
+      livePreview: true
+  });
+
   $('.simple_color_callback').simpleColor({
       callback: function( hex ) {
         alert("You selected #" + hex);
@@ -27,6 +31,7 @@ $(document).ready(function(){
       border: '1px solid #660033',
       buttonClass: 'button',
       displayColorCode: true,
+      livePreview: true,
       callback: function( hex ) {
         alert("You selected #" + hex);
       },
@@ -35,7 +40,7 @@ $(document).ready(function(){
       },
       onClose: function() {
         alert("color selector closed");
-      }
+      },
   });
 
 });
@@ -66,6 +71,9 @@ $(document).ready(function(){
 
   <h3>Custom Cell Size</h3>
   <input class='simple_color_custom_cell_size' value='#cc9966'/>
+
+  <h3>With LivePreview</h3>
+  <input class='simple_color_live_preview' value='#ff00ff'/>
 
   <h3>With Callback</h3>
   <input class='simple_color_callback' value='#cc3333'/>


### PR DESCRIPTION
:warning: dependent on: https://github.com/recurser/jquery-simple-color/pull/7

This changes the color of the color display as the user mouses over the color cells. If no color is selected and the selector is closed, the display will revert to the original color automatically.

usage:

``` javascript
 $('.simple_color_live_preview').simpleColor({
      livePreview: true
  });
```
